### PR TITLE
Bug Fix: Reset fileIndex

### DIFF
--- a/Arduino/Arduino_4-10.c
+++ b/Arduino/Arduino_4-10.c
@@ -189,6 +189,7 @@ void loop()
         }
       }
     
+	fileIndex = 0;
     time_index = 0; //reset time_index
     //delay(2000);
 


### PR DESCRIPTION
Resets file index to 0  after sending.
Keeps file indexes from incrementing forever.